### PR TITLE
add custom controls template as required

### DIFF
--- a/controller/project.py
+++ b/controller/project.py
@@ -187,6 +187,7 @@ class Project:
                     self.p_path("frontend", "app", "custom.footer.ts"),
                     self.p_path("frontend", "app", "custom.profile.ts"),
                     self.p_path("frontend", "app", "custom.navbar.links.html"),
+                    self.p_path("frontend", "app", "custom.navbar.controls.html"),
                     self.p_path("frontend", "app", "custom.navbar.brand.html"),
                     self.p_path("frontend", "app", "custom.footer.html"),
                     self.p_path("frontend", "app", "custom.profile.html"),

--- a/controller/templates/custom.navbar.controls.html.j2
+++ b/controller/templates/custom.navbar.controls.html.j2
@@ -1,0 +1,17 @@
+<!--
+<li class="nav-item dropdown" ngbDropdown>
+  <a class="nav-link" href="javascript:void(0)" ngbDropdownToggle>
+    <i class="fa fa-language"></i>Language<b class="caret"></b>
+  </a>
+  <div class="dropdown-menu-right" ngbDropdownMenu>
+    <a (click)="changeLang('en')" class="dropdown-item" href="javascript:void(0)">English</a>
+    <a (click)="changeLang('it')" class="dropdown-item" href="javascript:void(0)">Italian</a>
+  </div>
+</li>
+-->
+
+<!--
+<li class="nav-item">
+  <a class="nav-link" href="javascript:void(0)">foo</a>
+</li>
+-->

--- a/controller/templates/custom.navbar.ts.j2
+++ b/controller/templates/custom.navbar.ts.j2
@@ -40,3 +40,19 @@ export class CustomBrandComponent {
     this.project = t;
   }
 }
+
+@Component({
+  selector: "customcontrols",
+  templateUrl: "custom.navbar.controls.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CustomControlsComponent {
+  @Input() user: User;
+  @Output() onClick: EventEmitter<null> = new EventEmitter<null>();
+
+  constructor() {}
+
+  public collapse() {
+    this.onClick.emit();
+  }
+}


### PR DESCRIPTION
Enable the custom control template as explained [here](https://github.com/rapydo/rapydo-angular/pull/366#issuecomment-1733781956) .  
The template is intentionally kept blank.
